### PR TITLE
quick dirty fix for 32bit darwin

### DIFF
--- a/poll/poll_darwin_386.go
+++ b/poll/poll_darwin_386.go
@@ -1,5 +1,3 @@
-// +build darwin,amd64 freebsd dragonfly netbsd openbsd
-
 package poll
 
 import (
@@ -21,7 +19,7 @@ func New(fd int) (p *Poller, err error) {
 	}
 
 	p.event = syscall.Kevent_t{
-		Ident:  uint64(fd),
+		Ident:  uint32(fd),
 		Filter: syscall.EVFILT_WRITE,
 		Flags:  syscall.EV_ADD | syscall.EV_ENABLE | syscall.EV_ONESHOT,
 		Fflags: 0,


### PR DESCRIPTION
On 32bit darwin the `syscall.Keven_t.Ident` Field is 32bit and thus needs to be `uint32`. I expect that this is similarly true for other 32bit systems.

There most likely is a cleaner way to abstract this stuff in the `poll` package.

See  for more jbenet/go-ipfs#828.