### PR TITLE
Add arm64 support to build constraints for use on iOS (darwin,arm64)

### DIFF
--- a/poll/poll_bsd.go
+++ b/poll/poll_bsd.go
@@ -1,4 +1,4 @@
-// +build darwin,amd64 freebsd dragonfly netbsd openbsd
+// +build darwin,amd64 darwin,arm64 freebsd dragonfly netbsd openbsd
 
 package poll
 


### PR DESCRIPTION
Allows go-reuseport (and any package using it, e.g. ipfs) to produce working Poll with darwin,arm64 build constraints.